### PR TITLE
Fix EmployerMailVO name

### DIFF
--- a/src/Dominio/AggRoots/Employer/ValueObjects/EmployerMailVo.ts
+++ b/src/Dominio/AggRoots/Employer/ValueObjects/EmployerMailVo.ts
@@ -1,4 +1,4 @@
-export class EmployerEmailVo {
+export class EmployerMailVo {
     value: string;
     regex = RegExp(/^[-\w.%+]{1,64}@(?:[A-Z0-9-]{1,63}\.){1,125}[A-Z]{2,63}$/i);
     


### PR DESCRIPTION
Cambiado el nombre del value object EmployerEmailVo a EmployerMailVo porque debe coincidir con el nombre descrito en el diagrama UML del dominio